### PR TITLE
Add multi-exchange price fetch script

### DIFF
--- a/fetch_prices.py
+++ b/fetch_prices.py
@@ -1,0 +1,46 @@
+import ccxt
+import pandas as pd
+from datetime import datetime
+
+EXCHANGES = {
+    "binance": "BTCUSDT",
+    "bybit": "BTCUSDT",
+    "okx": "BTC-USDT",
+    "kucoin": "BTC-USDT",
+    "mexc": "BTCUSDT",
+    "bitget": "BTCUSDT",
+    "bitmex": "XBTUSD",
+    "bitbank": "btc_jpy",
+    "gmocoin": "BTC_JPY",
+    "hyperliquid": "BTC",
+}
+
+TIMEFRAMES = ["1h", "1d"]
+
+
+def fetch_ohlcv(exchange_name: str, symbol: str, timeframe: str):
+    """Fetch OHLCV data using ccxt."""
+    if not hasattr(ccxt, exchange_name):
+        raise ValueError(f"Exchange '{exchange_name}' not supported by ccxt")
+
+    exchange = getattr(ccxt, exchange_name)({"enableRateLimit": True})
+    ohlcv = exchange.fetch_ohlcv(symbol, timeframe=timeframe)
+    # convert to DataFrame
+    df = pd.DataFrame(ohlcv, columns=["timestamp", "open", "high", "low", "close", "volume"])
+    df["timestamp"] = pd.to_datetime(df["timestamp"], unit="ms")
+    return df
+
+
+def main():
+    for name, symbol in EXCHANGES.items():
+        for tf in TIMEFRAMES:
+            try:
+                df = fetch_ohlcv(name, symbol, tf)
+                print(f"{name} {symbol} {tf}:")
+                print(df.tail())
+            except Exception as e:
+                print(f"Error fetching {name} {symbol} {tf}: {e}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add standalone `fetch_prices.py` for grabbing hourly and daily OHLCV data from several exchanges via ccxt

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'ccxt')*

------
https://chatgpt.com/codex/tasks/task_e_68b1cdbfc900832aa1ae7f32de30474b